### PR TITLE
Fixed issue #16: Obscured password in login and sign-up pages

### DIFF
--- a/lib/Utils/Textbox.dart
+++ b/lib/Utils/Textbox.dart
@@ -5,11 +5,13 @@ class Textbox extends StatelessWidget {
   final TextEditingController controller;
   final IconData icons;
   final String? errormsg;
+  final bool obscureText;
 
   Textbox({
     super.key,
     required this.name,
     required this.controller,
+    required this.obscureText,
     required this.icons,
     this.errormsg,
   });
@@ -19,7 +21,7 @@ class Textbox extends StatelessWidget {
     return ClipRRect(
       borderRadius: BorderRadius.circular(10),
       child: TextFormField(
-        
+        obscureText: obscureText,
         cursorColor: Color.fromRGBO(18, 79, 43, 1),
         style: const TextStyle(
           color: Color.fromARGB(255, 18, 79, 43),
@@ -28,21 +30,18 @@ class Textbox extends StatelessWidget {
         ),
         controller: controller,
         decoration: InputDecoration(
-          
           hintText: name,
           hintStyle: const TextStyle(
             color: Color.fromARGB(255, 18, 79, 43),
             fontSize: 16,
             fontWeight: FontWeight.w500,
           ),
-          
           errorText: errormsg,
           errorBorder: InputBorder.none,
           errorStyle: const TextStyle(
             fontWeight: FontWeight.w400,
             fontSize: 14,
           ),
-          
           focusedErrorBorder: InputBorder.none,
           prefixIcon: Icon(
             icons,

--- a/lib/views/pages/login/login.dart
+++ b/lib/views/pages/login/login.dart
@@ -1,8 +1,9 @@
 import 'package:donorconnect/views/pages/main_home/homepage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
-import '../register/signup.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import '../../../Utils/Textbox.dart';
+import '../register/signup.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -32,7 +33,8 @@ class _LoginPageState extends State<LoginPage> {
 
   Future<void> loginUser() async {
     if (emailController.text.isNotEmpty && passwordController.text.isNotEmpty) {
-      Navigator.push(context, MaterialPageRoute(builder: (context)=>const HomePage()));
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => const HomePage()));
       // setState(() {
       //   _isValidate = false; // Reset validation flag
       // });
@@ -89,6 +91,7 @@ class _LoginPageState extends State<LoginPage> {
                     children: [
                       Textbox(
                         controller: emailController,
+                        obscureText: false,
                         icons: Icons.email,
                         name: 'Email',
                         errormsg: _isValidate ? 'Please enter Email' : null,
@@ -100,6 +103,7 @@ class _LoginPageState extends State<LoginPage> {
                       ),
                       Textbox(
                         controller: passwordController,
+                        obscureText: true,
                         icons: Icons.lock,
                         name: 'Password',
                         errormsg: _isValidate ? 'Please enter Password' : null,

--- a/lib/views/pages/register/signup.dart
+++ b/lib/views/pages/register/signup.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '../../../Utils/Textbox.dart';
 
 class Signuppage extends StatefulWidget {
@@ -80,6 +81,7 @@ class _SignuppageState extends State<Signuppage> {
                   // EMAIL TEXTBOX
                   Textbox(
                     controller: emailController,
+                    obscureText: false,
                     icons: Icons.mail,
                     name: 'Email',
                     errormsg: _isValidate ? 'Please enter Email' : null,
@@ -89,6 +91,7 @@ class _SignuppageState extends State<Signuppage> {
                   // FULL NAME TEXTBOX
                   Textbox(
                     controller: nameController,
+                    obscureText: false,
                     icons: Icons.person,
                     name: 'Full name',
                     errormsg: _isValidate ? 'Please enter Full name' : null,
@@ -98,6 +101,7 @@ class _SignuppageState extends State<Signuppage> {
                   // PHONE NUMBER TEXTBOX
                   Textbox(
                     controller: numberController,
+                    obscureText: false,
                     icons: Icons.call,
                     name: 'Phone number',
                     errormsg: _isValidate ? 'Please enter Phone number' : null,
@@ -107,6 +111,7 @@ class _SignuppageState extends State<Signuppage> {
                   // PASSWORD TEXTBOX
                   Textbox(
                     controller: passwordController,
+                    obscureText: true,
                     icons: Icons.lock,
                     name: 'Create password',
                     errormsg: _isValidate ? 'Please enter Password' : null,
@@ -115,6 +120,7 @@ class _SignuppageState extends State<Signuppage> {
 
                   Textbox(
                     controller: passwordController,
+                    obscureText: true,
                     icons: Icons.lock,
                     name: 'Confirm password',
                     errormsg: _isValidate ? 'Please enter Password' : null,

--- a/lib/views/pages/register/signup.dart
+++ b/lib/views/pages/register/signup.dart
@@ -15,6 +15,7 @@ class _SignuppageState extends State<Signuppage> {
   TextEditingController numberController = TextEditingController();
   TextEditingController nameController = TextEditingController();
   TextEditingController passwordController = TextEditingController();
+  TextEditingController confirmPasswordController = TextEditingController();
   bool? check1 = false, check2 = false;
   bool _isValidate = false;
 
@@ -22,10 +23,26 @@ class _SignuppageState extends State<Signuppage> {
     if (emailController.text.isNotEmpty &&
         passwordController.text.isNotEmpty &&
         nameController.text.isNotEmpty &&
-        numberController.text.isNotEmpty) {
-      setState(() {
-        _isValidate = false; // Reset validation flag
-      });
+        numberController.text.isNotEmpty &&
+        confirmPasswordController.text.isNotEmpty) {
+      if (passwordController.text == confirmPasswordController.text) {
+        setState(() {
+          _isValidate = false; // Reset validation flag
+        });
+      } else {
+        showDialog(
+            context: context,
+            builder: (context) {
+              return const AlertDialog(
+                title: Center(
+                    child: Text(
+                  "Passwords don't match",
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                )),
+              );
+            });
+        _isValidate = true;
+      }
     } else {
       setState(() {
         _isValidate = true;
@@ -118,8 +135,9 @@ class _SignuppageState extends State<Signuppage> {
                   ),
                   SizedBox(height: screenHeight * 0.02),
 
+                  // CONFIRM PASSWORD
                   Textbox(
-                    controller: passwordController,
+                    controller: confirmPasswordController,
                     obscureText: true,
                     icons: Icons.lock,
                     name: 'Confirm password',


### PR DESCRIPTION
**Title:** 

Mask Password Input on Login and Sign-Up Pages

**Description:** 

This pull request resolves the issue of passwords being displayed in plain text on the Login and Sign-Up pages.

**Changes Made:**

Implemented password obscuring in the input fields to display dots (●●●●) instead of the actual characters.

**Steps to Verify:**

 Navigate to the Login or Sign-Up page.
 Enter a password and confirm it is masked.

**Screenshots:**
| ![Before](https://github.com/user-attachments/assets/3d595783-e10c-4c7a-87b2-71b17d6e0248) | ![After](https://github.com/user-attachments/assets/6a9cc283-b2c1-4a73-95cd-79af11126c78) |
|--------------------------------------|--------------------------------------|



