### PR TITLE
name in profile page made dynamic

### DIFF
--- a/lib/cubit/profile/profile_state.dart
+++ b/lib/cubit/profile/profile_state.dart
@@ -1,4 +1,7 @@
-class ProfileState {
+// profile_state.dart
+import 'package:equatable/equatable.dart';
+
+class ProfileState extends Equatable {
   final String name;
   final String medicalHistory;
   final String currentMedications;
@@ -7,8 +10,9 @@ class ProfileState {
   final bool isOrganDonor;
   final bool isBloodDonor;
   final bool notificationsEnabled;
+  final String errorMessage;
 
-  ProfileState({
+  const ProfileState({
     this.name = '',
     this.medicalHistory = '',
     this.currentMedications = '',
@@ -16,9 +20,11 @@ class ProfileState {
     this.bloodType = '',
     this.isOrganDonor = false,
     this.isBloodDonor = false,
-    this.notificationsEnabled = true,
+    this.notificationsEnabled = false,
+    this.errorMessage = '',
   });
 
+  // Adding a copyWith method to update the state with new data
   ProfileState copyWith({
     String? name,
     String? medicalHistory,
@@ -28,6 +34,7 @@ class ProfileState {
     bool? isOrganDonor,
     bool? isBloodDonor,
     bool? notificationsEnabled,
+    String? errorMessage,
   }) {
     return ProfileState(
       name: name ?? this.name,
@@ -38,6 +45,24 @@ class ProfileState {
       isOrganDonor: isOrganDonor ?? this.isOrganDonor,
       isBloodDonor: isBloodDonor ?? this.isBloodDonor,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+      errorMessage: errorMessage ?? this.errorMessage,
     );
+  }
+
+  @override
+  List<Object?> get props => [
+        name,
+        medicalHistory,
+        currentMedications,
+        allergies,
+        bloodType,
+        isOrganDonor,
+        isBloodDonor,
+        notificationsEnabled,
+        errorMessage,
+      ];
+
+  static ProfileState error({required String message}) {
+    return ProfileState(errorMessage: message);
   }
 }

--- a/lib/views/pages/login/login.dart
+++ b/lib/views/pages/login/login.dart
@@ -75,6 +75,7 @@ class _LoginPageState extends State<LoginPage> {
               MaterialPageRoute(
                 builder: (context) => HomePage(
                   email: emailController.text,
+                  name: state.user.name,
                 ),
               ),
             );

--- a/lib/views/pages/main_home/homepage.dart
+++ b/lib/views/pages/main_home/homepage.dart
@@ -24,6 +24,7 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     final controller =
         Get.put(NavigationController(widget.name ?? "No Name", widget.email!));
+        print(widget.name);
     return Scaffold(
       bottomNavigationBar: Obx(
         () => NavigationBar(

--- a/lib/views/pages/register/signup.dart
+++ b/lib/views/pages/register/signup.dart
@@ -155,7 +155,7 @@ class _SignuppageState extends State<Signuppage> {
               context,
               MaterialPageRoute(
                 builder: (context) => HomePage(
-                  name: nameController.text.trim(),
+                  name: nameController.text,
                   email: emailController.text.trim(),
                 ),
               ),


### PR DESCRIPTION
[Feature Request]: updating user name in profile page #50


This PR introduces the feature of displaying the user's name on the profile screen after they log in or sign up. Previously, the app was using a static name on the profile screen. Now, the actual name of the user (retrieved from Firebase) is displayed after login and sign-up, ensuring a more personalized experience.

Changes Made:
Implemented functionality in the AuthCubit to fetch user data (including the name) after login or sign-up.
The HomePage now dynamically displays the user's name passed from the AuthCubit instead of a static value.
Stored the user data in SharedPreferences to maintain the user's session and easily access the name across screens.

Testing:
Verified that the correct name is displayed after login and sign-up.
Checked that the name persists between app sessions using SharedPreferences.

Additional Notes:
This feature improves user experience by displaying personalized information on the profile screen.


https://github.com/user-attachments/assets/ab2250b5-d76f-4221-b78c-aa207f38433c

