### PR TITLE
password field updated

### DIFF
--- a/lib/Utils/Textbox.dart
+++ b/lib/Utils/Textbox.dart
@@ -6,6 +6,7 @@ class Textbox extends StatelessWidget {
   final IconData icons;
   final String? errormsg;
   final bool obscureText;
+  final Widget? suffixIcon; //optional suffix icon for visibility toggle
 
   Textbox({
     super.key,
@@ -13,7 +14,9 @@ class Textbox extends StatelessWidget {
     required this.controller,
     required this.obscureText,
     required this.icons,
-    this.errormsg,
+    this.errormsg, 
+    this.suffixIcon, // Accepting the optional suffic icon
+
   });
 
   @override
@@ -42,12 +45,14 @@ class Textbox extends StatelessWidget {
             fontWeight: FontWeight.w400,
             fontSize: 14,
           ),
+          errorMaxLines: 3,  // Allows error text to wrap to 3 lines
           focusedErrorBorder: InputBorder.none,
           prefixIcon: Icon(
             icons,
             size: 20,
           ),
           prefixIconColor: const Color.fromARGB(255, 18, 79, 43),
+          suffixIcon: suffixIcon,
           focusedBorder: InputBorder.none,
           enabledBorder: InputBorder.none,
           fillColor: Colors.white60,

--- a/lib/views/pages/register/signup.dart
+++ b/lib/views/pages/register/signup.dart
@@ -30,6 +30,10 @@ class _SignuppageState extends State<Signuppage> {
   bool _isPasswordValid = false;
   bool _isConfirmPasswordValid = false;
 
+  //variable to control password visibility
+  bool _isPasswordVisible =false;
+  bool _isConfirmPasswordVisible = false;
+
   bool isValidEmail(String email) {
     final RegExp emailRegExp = RegExp(
       r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
@@ -262,23 +266,44 @@ class _SignuppageState extends State<Signuppage> {
                       // PASSWORD TEXTBOX
                       Textbox(
                         controller: passwordController,
-                        obscureText: true,
+                        obscureText: ! _isPasswordVisible,
                         icons: Icons.lock,
                         name: _text.create_password,
                         errormsg:
                             _isPasswordValid ? _text.password_error_text : null,
+                         suffixIcon: IconButton(
+                          icon: Icon(
+                            _isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                          ),
+                          onPressed: () {
+                            setState(() {
+                              _isPasswordVisible = !_isPasswordVisible;
+                            });
+                          },
+                        ),
+                        
                       ),
                       SizedBox(height: screenHeight * 0.02),
 
                       // CONFIRM PASSWORD
                       Textbox(
                         controller: confirmPasswordController,
-                        obscureText: true,
+                        obscureText: ! _isConfirmPasswordVisible,
                         icons: Icons.lock,
                         name: _text.confirm_password,
                         errormsg: _isConfirmPasswordValid
                             ? _text.password_dont_match
                             : null,
+                         suffixIcon: IconButton(
+                          icon: Icon(
+                            _isConfirmPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                          ),
+                          onPressed: () {
+                            setState(() {
+                              _isConfirmPasswordVisible = !_isConfirmPasswordVisible;
+                            });
+                          },
+                        ),
                       ),
 
                       Row(


### PR DESCRIPTION
[Bug 🐞]: password visibility issue in signup screen #56


https://github.com/user-attachments/assets/b70a5417-5adf-4ec3-bc35-66ad096a3f46

![WhatsApp Image 2024-10-15 at 00 58 30_8ba0a7be](https://github.com/user-attachments/assets/64c89b85-a4c5-444b-91e0-58d0d38af472)

placeholder text in the password field should be "Create Password" but it is changed to "password number" during the multi language setup done by someone. I tried to change it but the change was not accepted so I left it as it is, if you feel this change is necessary kindly look into it.